### PR TITLE
Handle Instagram rate limits in scraper

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 instaloader>=4.10
 firebase-admin>=6.0
 geopy>=2.3
+python-dateutil>=2.8

--- a/scraper.py
+++ b/scraper.py
@@ -1,9 +1,11 @@
 import os
 import re
+import time
 from datetime import datetime, timedelta
 from typing import Iterable, Optional, Dict, Any
 
 import instaloader
+from dateutil.parser import ParserError, parse as parse_date
 from firebase_admin import credentials, firestore, initialize_app
 from geopy.geocoders import Nominatim
 
@@ -17,6 +19,8 @@ USERNAMES = [
 
 CAR_MEET_KEYWORD = "car meet"
 
+_GEOCODER = Nominatim(user_agent="meetz_scraper")
+
 def extract_address(text: str) -> Optional[str]:
     """Return a simple street address found in text if present."""
     pattern = r"\d{1,5}\s+[\w\s\.]+,\s*[\w\s\.]+,\s*[A-Z]{2}"
@@ -25,14 +29,21 @@ def extract_address(text: str) -> Optional[str]:
 
 
 def geocode(address: str) -> Optional[Dict[str, float]]:
-    geolocator = Nominatim(user_agent="meetz_scraper")
     try:
-        location = geolocator.geocode(address)
+        location = _GEOCODER.geocode(address)
     except Exception:
         location = None
     if location:
         return {"lat": location.latitude, "lng": location.longitude}
     return None
+
+
+def extract_event_datetime(text: str) -> Optional[datetime]:
+    """Return the first parseable datetime in ``text`` if present."""
+    try:
+        return parse_date(text, fuzzy=True)
+    except (ParserError, ValueError):
+        return None
 
 
 class InstagramCarMeetScraper:
@@ -47,29 +58,46 @@ class InstagramCarMeetScraper:
         initialize_app(cred)
         self.db = firestore.client()
 
-    def fetch_recent_posts(self, since_days: int = 7) -> Iterable[Dict[str, Any]]:
+    def fetch_recent_posts(self, since_days: int = 3) -> Iterable[Dict[str, Any]]:
+        """Yield recent car-meet related posts within ``since_days`` days."""
         since = datetime.utcnow() - timedelta(days=since_days)
 
         for username in USERNAMES:
             profile = instaloader.Profile.from_username(self.loader.context, username)
-            for post in profile.get_posts():
-                if post.date_utc < since:
+            while True:
+                try:
+                    for post in profile.get_posts():
+                        if post.date_utc < since:
+                            break
+                        caption = post.caption or ""
+                        if CAR_MEET_KEYWORD not in caption.lower():
+                            continue
+                        address = extract_address(caption)
+                        location = geocode(address) if address else None
+                        event_time = extract_event_datetime(caption)
+                        yield {
+                            "shortcode": post.shortcode,
+                            "url": f"https://www.instagram.com/p/{post.shortcode}/",
+                            "caption": caption,
+                            "taken_at": post.date_utc,
+                            "likes": post.likes,
+                            "username": username,
+                            "address": address,
+                            "location": location,
+                            "event_time": event_time,
+                        }
                     break
-                caption = post.caption or ""
-                if CAR_MEET_KEYWORD not in caption.lower():
-                    continue
-                address = extract_address(caption)
-                location = geocode(address) if address else None
-                yield {
-                    "shortcode": post.shortcode,
-                    "url": f"https://www.instagram.com/p/{post.shortcode}/",
-                    "caption": caption,
-                    "taken_at": post.date_utc.isoformat(),
-                    "likes": post.likes,
-                    "username": username,
-                    "address": address,
-                    "location": location,
-                }
+                except instaloader.exceptions.ConnectionException as exc:
+                    message = str(exc)
+                    if "please wait" in message.lower() or "401" in message:
+                        print(
+                            f"Rate limit hit for {username}: {message}. "
+                            "Sleeping before retry."
+                        )
+                        time.sleep(600)
+                        continue
+                    print(f"Connection error for {username}: {message}. Skipping user.")
+                    break
 
     def save_posts(self, posts: Iterable[Dict[str, Any]]):
         for post in posts:
@@ -86,7 +114,7 @@ def main() -> None:
     insta_pass = os.environ.get("INSTA_PASSWORD")
 
     scraper = InstagramCarMeetScraper(fb_key, insta_user, insta_pass)
-    posts = scraper.fetch_recent_posts(7)
+    posts = scraper.fetch_recent_posts()
     scraper.save_posts(posts)
 
 


### PR DESCRIPTION
## Summary
- retry fetching posts when Instagram returns connection errors indicating rate limiting
- pull car meet posts from last three days, parse event time, and geocode addresses before saving

## Testing
- `python -m py_compile scraper.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ec3d62f408332bcff75919abfb21b